### PR TITLE
Bump org.apache.xmlgraphics:batik-transcoder from 1.14 to 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-transcoder</artifactId>
-            <version>1.14</version>
+            <version>1.17</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps org.apache.xmlgraphics:batik-transcoder from 1.14 to 1.17.

---
updated-dependencies:
- dependency-name: org.apache.xmlgraphics:batik-transcoder dependency-type: direct:production ...